### PR TITLE
fix #12 using kv argment to defining for name-bang macro

### DIFF
--- a/lib/qlc/record.ex
+++ b/lib/qlc/record.ex
@@ -25,18 +25,15 @@ defmodule Qlc.Record do
 
 
   """
-  defmacro defrecord(tag, args) do
-    vtag = :"#{tag}!"
-    quote do 
+  defmacro defrecord(name, tag \\ nil, args) do
+    vname = :"#{name}!"
+    quote do
       require Elixir.Record
-      m = unquote(tag)
+      #m = unquote(tag)
       #IO.inspect(tag: quote do: unquote(m))
-      Elixir.Record.defrecord(unquote(tag), unquote(args))
-      def __fields__(unquote(tag)) do
-        Elixir.Record.__fields__(unquote(tag), unquote(args))
-      end
-      defmacro unquote(vtag)(x,a) do
-        f = Elixir.Record.__fields__(unquote(tag), unquote(args))
+      Elixir.Record.defrecord(unquote(name), unquote(tag), unquote(args))
+      defmacro unquote(vname)(x,a) do
+        f = unquote(args)
         y = case x do
               {:__aliases__, _, [y]} ->
                 Atom.to_string(y)

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Qlc.Mixfile do
           "GitHub" => @url_github
         }
       },
-      version: "1.0.9",
+      version: "1.0.10",
       elixir: "~> 1.7",
       deps: deps(),
       docs: [


### PR DESCRIPTION
In Qlc.Record.defmacro, using Record.__fields__/2 to defining name-bang macro, 
but removed Recrd.__fields__/2 since [Add reflection of records](https://github.com/elixir-lang/elixir/commit/f32a4a3f22629518e850a01067226cbe7c04c2b4).
using kv argument to defining name-bang macro.
